### PR TITLE
fixed a string formatting issue that causes error on Windows

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -14,8 +14,11 @@ class Downloader:
         with requests.get(url, stream=True) as r :
             r.raise_for_status()
             curr_dir = os.path.dirname(__file__)
+            dl_dir = os.path.join(curr_dir,'downloads')
+            if not os.path.isdir(dl_dir):
+                os.mkdir(dl_dir)
             if albumName != '':
-                path = os.path.join(curr_dir, f"downloads/{albumName}") 
+                path = os.path.join(dl_dir, albumName) 
             else:
                 path = os.path.join(curr_dir, "downloads/") 
             if not os.path.isdir(path):


### PR DESCRIPTION
The formatted string on line 18 used os-dependent notation causing an issue on Windows 10 (tested under conda env, see attached image). Simple fix uses os.path.join() instead to format the string os-independently

`                path = os.path.join(curr_dir, f"downloads/{albumName}") `

Haven't tested but a similar issue may arise on line 20 (now 23)

`                path = os.path.join(curr_dir, "downloads/") `

![Screenshot 2022-12-22 163304](https://user-images.githubusercontent.com/26271596/209146353-19631b6a-e07e-40c6-b06c-7156e29d2d6b.png)
